### PR TITLE
Fix issue #2 playa-mesos method to override version is broken

### DIFF
--- a/playa-mesos/Vagrantfile
+++ b/playa-mesos/Vagrantfile
@@ -77,16 +77,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       master_ip = hosts["mesos-master"]["ip"]
 
-      if pmconf.mesos_release != "" && pmconf.has_key?("mesos_release")
+      if pmconf.instance_variable_get(:@settings).include?('mesos_release')
         mesos_release = pmconf.mesos_release.split('-')[0]
       else
         mesos_release = "0.26.0"
       end
 
-      if pmconf.isolator_version != "" && pmconf.has_key?("isolator_version") 
+      if pmconf.instance_variable_get(:@settings).include?('isolator_version')
         isolator_version = pmconf.isolator_version
       else
-        isolator_version = "0.4.0"
+        isolator_version = "0.4.1"
       end
 
 

--- a/playa-mesos/config.json
+++ b/playa-mesos/config.json
@@ -25,7 +25,7 @@
       "ip":"10.141.141.14",
       "external_volumes":true
     }
-	},
+  },
   "vm_ram": "1024",
   "vm_cpus": "1"
 }

--- a/playa-mesos/examples/config.json.0.23.0
+++ b/playa-mesos/examples/config.json.0.23.0
@@ -1,0 +1,21 @@
+{
+  "platform": "virtualbox",
+  "box_name": "playa_mesos_ubuntu_14.04_201601041324",
+  "base_url": "http://downloads.mesosphere.io/playa-mesos",
+  "mesos_release": "0.23.0-1.0.ubuntu1404",
+  "isolator_version": "0.4.1",
+  "hosts": {
+    "mesos-master": {
+      "ip": "10.141.141.10",
+      "vm_ram": "1612",
+      "vm_cpus": "1",
+      "external_volumes": true
+    },
+    "mesos-slave1": {
+      "ip": "10.141.141.11",
+      "vm_ram": "1024",
+      "vm_cpus": "1",
+      "external_volumes": true
+    }
+  }
+}

--- a/playa-mesos/examples/config.json.0.24.1
+++ b/playa-mesos/examples/config.json.0.24.1
@@ -1,0 +1,21 @@
+{
+  "platform": "virtualbox",
+  "box_name": "playa_mesos_ubuntu_14.04_201601041324",
+  "base_url": "http://downloads.mesosphere.io/playa-mesos",
+  "mesos_release": "0.24.1-0.2.35.ubuntu1404",
+  "isolator_version": "0.4.1",
+  "hosts": {
+    "mesos-master": {
+      "ip": "10.141.141.10",
+      "vm_ram": "1612",
+      "vm_cpus": "1",
+      "external_volumes": true
+    },
+    "mesos-slave1": {
+      "ip": "10.141.141.11",
+      "vm_ram": "1024",
+      "vm_cpus": "1",
+      "external_volumes": true
+    }
+  }
+}

--- a/playa-mesos/examples/config.json.0.26.0
+++ b/playa-mesos/examples/config.json.0.26.0
@@ -1,0 +1,21 @@
+{
+  "platform": "virtualbox",
+  "box_name": "playa_mesos_ubuntu_14.04_201601041324",
+  "base_url": "http://downloads.mesosphere.io/playa-mesos",
+  "mesos_release": "0.26.0-0.2.145.ubuntu1404",
+  "isolator_version": "0.4.1",
+  "hosts": {
+    "mesos-master": {
+      "ip": "10.141.141.10",
+      "vm_ram": "1612",
+      "vm_cpus": "1",
+      "external_volumes": true
+    },
+    "mesos-slave1": {
+      "ip": "10.141.141.11",
+      "vm_ram": "1024",
+      "vm_cpus": "1",
+      "external_volumes": true
+    }
+  }
+}

--- a/playa-mesos/examples/config.json.0.27.0
+++ b/playa-mesos/examples/config.json.0.27.0
@@ -1,0 +1,21 @@
+{
+	"platform": "virtualbox",
+	"box_name": "playa_mesos_ubuntu_14.04_201601041324",
+	"base_url": "http://downloads.mesosphere.io/playa-mesos",
+	"mesos_release": "0.27.0-0.2.190.ubuntu1404",
+	"isolator_version": "0.4.1",
+	"hosts": {
+		"mesos-master": {
+			"ip": "10.141.141.10",
+			"vm_ram": "1612",
+			"vm_cpus": "1",
+			"external_volumes": true
+		},
+		"mesos-slave1": {
+			"ip": "10.141.141.11",
+			"vm_ram": "1024",
+			"vm_cpus": "1",
+			"external_volumes": true
+		}
+	}
+}


### PR DESCRIPTION
edited Vagrantfile to fix flaws in detecting version override in config.son

cleaned up provided config.json to remove mix of tabs and spaces used for indentation - changed to all spaces to make consistent

Added config.son examples for multiple recent versions of Mesos for the convenience of those who dev/test across multiple versions. They can just copy over config.json to spin up the version of choice.
