### PR TITLE
Fixed java install issue for gateway

### DIFF
--- a/scaleio/scripts/mdm1.sh
+++ b/scaleio/scripts/mdm1.sh
@@ -75,7 +75,9 @@ echo VERSION_SUMMARY = $VERSION_SUMMARY
 
 truncate -s 100GB ${DEVICE}
 yum install numactl libaio -y
-yum install java-1.8.0-openjdk -y
+yum install wget -y
+wget -nv --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u60-b27/jre-8u60-linux-x64.rpm" -O /tmp/jre.rpm
+rpm -ivvh /tmp/jre.rpm
 
 
 cd /vagrant


### PR DESCRIPTION
This fix updates the java version to be Oracle instead of openjdk
to fix issues relating to keychain for the gateway and an
incompatible java version.
