### PR TITLE
Fixing the REX-Ray configuration file

### DIFF
--- a/scaleio/scripts/rexray.sh
+++ b/scaleio/scripts/rexray.sh
@@ -1,7 +1,5 @@
 curl -sSL https://dl.bintray.com/emccode/rexray/install | sh -s -- stable
 cat << EOF > /etc/rexray/config.yml
-rexray:
-  logLevel: warn
 libstorage:
   service: scaleio
   integration:
@@ -9,12 +7,9 @@ libstorage:
       operations:
         mount:
           preempt: true
-        unmount:
-          ignoreusedcount: true
 scaleio:
   endpoint: https://192.168.50.12/api
   insecure: true
-  apiVersion: "2.0"
   useCerts: true
   userName: admin
   password: 'Scaleio123'


### PR DESCRIPTION
removed unused count because it's not needed. Removed logging level because it's warn by default. Remove the specific api because by default it will ask the endpoint what version of the API to use.

Signed-off-by: Kendrick Coleman kendrickcoleman@gmail.com
