### PR TITLE
Fixed the paths to work with ScaleIO 2.0.0.3

### DIFF
--- a/scaleio/scripts/mdm1.sh
+++ b/scaleio/scripts/mdm1.sh
@@ -83,7 +83,7 @@ yum install unzip numactl libaio -y
 yum install java-1.8.0-openjdk -y
 
 cd /vagrant
-DIR=`unzip -l "ScaleIO_Linux_v"$VERSION_MAJOR_MINOR".zip" | awk '{print $4}' | grep $ZIP_OS | awk -F'/' '{print $1 "/" $2}' | head -1`
+DIR=`unzip -l "ScaleIO_Linux_v"$VERSION_MAJOR_MINOR".zip" | awk '{print $4}' | grep $ZIP_OS | awk -F'/' '{print $1 "/" $2 "/" $3}' | head -1`
 
 echo "Entering directory /vagrant/scaleio/$DIR"
 cd /vagrant/scaleio/$DIR
@@ -115,9 +115,9 @@ fi
 
 # Always install ScaleIO Gateway
 cd /vagrant
-DIR=`unzip -l "ScaleIO_Linux_v"$VERSION_MAJOR_MINOR".zip" | awk '{print $4}' | grep Gateway_for_Linux | awk -F'/' '{print $1 "/" $2}' | head -1`
+DIR=`unzip -l "ScaleIO_Linux_v"$VERSION_MAJOR_MINOR".zip" | awk '{print $4}' | grep Gateway_for_Linux | awk -F'/' '{print $1 "/" $2 "/" $3}' | head -1`
 cd /vagrant/scaleio/$DIR
-
+echo "Installing GATEWAY $GWRPM"
 GWRPM=`ls -1 | grep x86_64`
 GATEWAY_ADMIN_PASSWORD=${PASSWORD} rpm -Uv $GWRPM --nodeps 2>/dev/null
 
@@ -128,7 +128,7 @@ service scaleio-gateway restart
 
 # Copy the ScaleIO GUI application to the /vagrant directory for easy access
 cd /vagrant
-DIR=`unzip -l "ScaleIO_Linux_v"$VERSION_MAJOR_MINOR".zip" | awk '{print $4}' | grep GUI_for_Linux | awk -F'/' '{print $1 "/" $2}' | head -1`
+DIR=`unzip -l "ScaleIO_Linux_v"$VERSION_MAJOR_MINOR".zip" | awk '{print $4}' | grep GUI_for_Linux | awk -F'/' '{print $1 "/" $2 "/" $3}' | head -1`
 cd /vagrant/scaleio/$DIR
 GUIRPM=`ls -1 | grep rpm`
 rpm2cpio $GUIRPM | cpio -idmv

--- a/scaleio/scripts/mdm2.sh
+++ b/scaleio/scripts/mdm2.sh
@@ -89,7 +89,7 @@ truncate -s 100GB ${DEVICE}
 yum install unzip numactl libaio -y
 
 cd /vagrant
-DIR=`unzip -l "ScaleIO_Linux_v"$VERSION_MAJOR_MINOR".zip" | awk '{print $4}' | grep $ZIP_OS | awk -F'/' '{print $1 "/" $2}' | head -1`
+DIR=`unzip -l "ScaleIO_Linux_v"$VERSION_MAJOR_MINOR".zip" | awk '{print $4}' | grep $ZIP_OS | awk -F'/' '{print $1 "/" $2 "/" $3}' | head -1`
 
 echo "Entering directory /vagrant/scaleio/$DIR"
 cd /vagrant/scaleio/$DIR

--- a/scaleio/scripts/tb.sh
+++ b/scaleio/scripts/tb.sh
@@ -85,7 +85,7 @@ fi
 echo "Uncompressing SIO package"
 unzip -n "ScaleIO_Linux_v"$VERSION_MAJOR_MINOR".zip" -d /vagrant/scaleio/
 
-DIR=`unzip -l "ScaleIO_Linux_v"$VERSION_MAJOR_MINOR".zip" | awk '{print $4}' | grep $ZIP_OS | awk -F'/' '{print $1 "/" $2}' | head -1`
+DIR=`unzip -l "ScaleIO_Linux_v"$VERSION_MAJOR_MINOR".zip" | awk '{print $4}' | grep $ZIP_OS | awk -F'/' '{print $1 "/" $2 "/" $3}' | head -1`
 
 echo "Entering directory /vagrant/scaleio/$DIR"
 cd /vagrant/scaleio/$DIR


### PR DESCRIPTION
ScaleIO version 2.0.0.3 introduced new paths, this PR will fix those paths so we the setup works with the currently latest version of ScaleIO.

Signed-off-by: <jonas.rosland@gmail.com>