### PR TITLE
fixed ScaleIO vagrant

### DIFF
--- a/scaleio/Vagrantfile
+++ b/scaleio/Vagrantfile
@@ -67,11 +67,13 @@ Vagrant.configure("2") do |config|
   end
   #config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 
-  config.trigger.after :up, :stdout => true, :vm => ["mdm2"] do
-    info "Restarting Docker on all nodes"
-    run "vagrant ssh tb -c 'sudo service docker restart'"
-    run "vagrant ssh mdm1 -c 'sudo service docker restart'"
-    run "vagrant ssh mdm2 -c 'sudo service docker restart'"
+  if rexrayinstall == "True"
+    config.trigger.after :up, :stdout => true, :vm => ["mdm2"] do
+      info "Restarting Docker on all nodes"
+      run "vagrant ssh tb -c 'sudo service docker restart'"
+      run "vagrant ssh mdm1 -c 'sudo service docker restart'"
+      run "vagrant ssh mdm2 -c 'sudo service docker restart'"
+    end
   end
 
   scaleio_nodes.each do |node|


### PR DESCRIPTION
If RR install was set to False, the Vagrant-triggers plugin would still run. Now it will only run when RR is set to True

Signed-off-by: Kendrick Coleman <kendrickcoleman@gmail.com>