### PR TITLE
updated guide and script and Vagrantfile

### DIFF
--- a/ceph/README.md
+++ b/ceph/README.md
@@ -1,14 +1,17 @@
 # REX-Ray + Ceph RBD
 
-This is a Vagrant environment using `VirtualBox` and
-`Virtual Media` as storage for Ceph to be consumed by REX-Ray along with
-Docker as the container runtime.  This can be used as a quick way
-to get started working with Ceph and REX-Ray.
+This Vagrant environment uses `VirtualBox` and `Virtual Media` as storage for
+Ceph to be consumed by REX-Ray. Docker is used as the container runtime allowing
+a quick way to get started using Ceph and REX-Ray. 
 
 The `RBD` storage driver within REX-Ray is attaching RADOS Block Devices (RBD)
-to the Vagrant VMs.  This enables the persistent volumes to be
-moved between containers, which allow container hosts to be immutable and
-containers to remain non-persistent.
+to the Vagrant VMs. This enables the persistent volumes to be moved between
+containers, which allow container hosts to be immutable and containers to remain
+non-persistent.
+
+The environment uses 3 Virtual Machines. One machine labeled as `ceph-admin` to
+be used for running the containers and checking cluster status. The other two
+machines, `ceph-server-1` and `ceph-server-2` are providing storage.
 
 ## Installation
 
@@ -16,31 +19,52 @@ containers to remain non-persistent.
 ```
 git clone https://github.com/codedellemc/vagrant
 cd vagrant/ceph
+ssh-add ~/.vagrant.d/insecure_private_key
 vagrant up
 ```
-
-## Usage
-When the Vagrant environment is up and running, you can now run
-`vagrant ssh ceph-admin` to get into the VM.  Since REX-Ray requires root
-privileges for mounting, etc you can at this point issue something similar to
-`sudo -i` to ensure you are running as root.
-
-You can check the status of the Ceph cluster with `ceph -s`. You should be
-able to immediately run commands like `rexray volume create` and
-`rexray volume ls`, or do the same thing with docker via `docker volume create`
-and `docker volume ls`
 
 **NOTE**: The VMs contain the default Vagrant insecure SSH public key, such that
 `vagrant ssh` works by default. However, the `ceph-admin` VM needs to be able to
 SSH to the other VMs in order to configure Ceph via `ceph-deploy`. In order to
-do this, the Vagrant SSH private key must be in your local SSH agent. The most
+do this, the Vagrant SSH private key must be in your local SSH agent. Configuration of the Ceph cluster will not work without this step. The most
 typical way to accomplish this on a nix-like machine is by running the command:
 
 ```
 ssh-add ~/.vagrant.d/insecure_private_key
 ```
 
-Configuration of the Ceph cluster will not work without this step.
+
+## Usage
+When the Vagrant environment is up and running, run `vagrant ssh ceph-admin` to
+get into the VM.  Since REX-Ray requires root privileges for mounting, etc,
+run the rest of the lab as root:
+
+```
+sudo -i
+```
+
+Check the status of the Ceph cluster with:
+
+```
+ceph -s
+```
+
+The REX-Ray command line is available at this time:
+
+```
+rexray volume create <name> --size=X
+rexray volume ls
+```
+
+The Docker Command line can be invoked as well for volume operation
+
+```
+docker volume create -d rexray --name <name> --opt=size=X
+docker volume ls
+```
+
+Go to the [Application Demo of {code} Labs](https://github.com/codedellemc/labs#application-demo) to look at running applications like Postgres.
+
 
 ## Options
 There are optional fields in the `Vagrantfile` that can be modified or
@@ -57,7 +81,7 @@ commented and uncommented.
 
 Only one of the install options is intended to be set to true at one time.
 Setting multiple to true will result in wasted work, as each one overwrites the
-other. Setting all to false will result in no new rexray being installed,
+other. Setting all to `false` will result in rexray not being installed,
 leaving whatever happens to be pre-installed in the vagrant box.
 
 When using `install_rex_from_source`, it is also possible to modify the
@@ -69,15 +93,21 @@ Consult the full REX-Ray documentation [here](http://rexray.readthedocs.org/en/s
 
 Get information on the existing volumes:
 
-`rexray volume ls`
+```
+rexray volume ls
+```
 
 Create a new volume:
 
-`rexray volume create --size=20 test`
+```
+rexray volume create --size=20 test
+```
 
 Delete a volume:
 
-`rexray volume remove test`
+```
+rexray volume remove test
+```
 
 ## Docker
 Consult the Docker and REX-Ray documentation [here](http://rexray.readthedocs.io/en/stable/user-guide/schedulers/#docker).  

--- a/ceph/Vagrantfile
+++ b/ceph/Vagrantfile
@@ -9,9 +9,9 @@ network = "172.21.13"
 
 # Flags to control which REX-Ray to install
 # Setting all options to false will use whatever rexray is already present
-install_latest_stable_rex = false
+install_latest_stable_rex = true
 install_latest_staged_rex = false
-install_rex_from_source = true
+install_rex_from_source = false
 
 
 # Script to build rexray from source

--- a/ceph/rexconfig.sh
+++ b/ceph/rexconfig.sh
@@ -11,4 +11,4 @@ libstorage:
       preempt: false
 EOF
 
-sudo systemctl restart rexray
+sudo rexray start

--- a/scaleio/Vagrantfile
+++ b/scaleio/Vagrantfile
@@ -27,7 +27,7 @@ secondmdmip = "#{network}.13"
 clusterinstall = "True" #If True a fully working ScaleIO cluster is installed. False mean only IM is installed on node MDM1.
 
 # Install Docker and REX-Ray automatically
-rexrayinstall = "True"
+rexrayinstall = "False"
 
 # version of installation package
 version = "2.0-0.0"


### PR DESCRIPTION
updated the Vagrant file to no longer build from source since it's now part of the stable release. Changed the script to run rexray as a service instead of invoking systemctl since it hasn't been installed as a service. updated the guide to better reflect the labs way of doing tutorials.

Signed-off-by: Kendrick Coleman <kendrickcoleman@gmail.com>