### PR TITLE
fix ScaleIO install and set RR and Docker to True

### DIFF
--- a/scaleio/Vagrantfile
+++ b/scaleio/Vagrantfile
@@ -27,7 +27,7 @@ secondmdmip = "#{network}.13"
 clusterinstall = "True" #If True a fully working ScaleIO cluster is installed. False mean only IM is installed on node MDM1.
 
 # Install Docker and REX-Ray automatically
-rexrayinstall = "False"
+rexrayinstall = "True"
 
 # version of installation package
 version = "2.0-0.0"
@@ -36,7 +36,7 @@ version = "2.0-0.0"
 os="el7"
 
 #ZIP OS Version of package
-zip_os="RHEL7"
+zip_os="OEL7"
 
 # installation folder
 siinstall = "/opt/scaleio/siinstall"


### PR DESCRIPTION
ScaleIO zip file renamed it to OEL7 instead of RHEL7. Now SclaeIO components are correctly installed. Set the flag to true for default installation of REX-Ray and Docker

Signed-off-by: Kendrick Coleman <kendrickcoleman@gmail.com>