### PR TITLE
hotfix for scaleio when interface starts down

### DIFF
--- a/scaleio/scripts/mdm1.sh
+++ b/scaleio/scripts/mdm1.sh
@@ -77,6 +77,12 @@ echo VERSION_MAJOR = $VERSION_MAJOR
 echo VERSION_MAJOR_MINOR = $VERSION_MAJOR_MINOR
 echo VERSION_SUMMARY = $VERSION_SUMMARY
 
+echo "Checking Interface State: enp0s8"
+INTERFACE_STATE=$(cat /sys/class/net/enp0s8/operstate)
+if [ "${INTERFACE_STATE}" == "down" ]; then
+  echo "Bringing Up Interface: enp0s8"
+  ifup enp0s8
+fi
 
 truncate -s 100GB ${DEVICE}
 yum install unzip numactl libaio -y

--- a/scaleio/scripts/mdm2.sh
+++ b/scaleio/scripts/mdm2.sh
@@ -83,6 +83,12 @@ echo VERSION_MAJOR = $VERSION_MAJOR
 echo VERSION_MAJOR_MINOR = $VERSION_MAJOR_MINOR
 echo VERSION_SUMMARY = $VERSION_SUMMARY
 
+echo "Checking Interface State: enp0s8"
+INTERFACE_STATE=$(cat /sys/class/net/enp0s8/operstate)
+if [ "${INTERFACE_STATE}" == "down" ]; then
+  echo "Bringing Up Interface: enp0s8"
+  ifup enp0s8
+fi
 
 #echo "Number files in SEARCH PATH with EXTENSION:" $(ls -1 "${SEARCHPATH}"/*."${EXTENSION}" | wc -l)
 truncate -s 100GB ${DEVICE}

--- a/scaleio/scripts/tb.sh
+++ b/scaleio/scripts/tb.sh
@@ -73,6 +73,13 @@ echo VERSION_MAJOR = $VERSION_MAJOR
 echo VERSION_MAJOR_MINOR = $VERSION_MAJOR_MINOR
 echo VERSION_SUMMARY = $VERSION_SUMMARY
 
+echo "Checking Interface State: enp0s8"
+INTERFACE_STATE=$(cat /sys/class/net/enp0s8/operstate)
+if [ "${INTERFACE_STATE}" == "down" ]; then
+  echo "Bringing Up Interface: enp0s8"
+  ifup enp0s8
+fi
+
 truncate -s 100GB ${DEVICE}
 yum install unzip numactl libaio wget -y
 cd /vagrant


### PR DESCRIPTION
on a fresh Ubuntu install and running the ScaleIO vagrant script, the enp0s8 interface would be down. This fix adds a check to see if it's down. If it is, bring it up

Signed-off-by: Kendrick Coleman <kendrickcoleman@gmail.com>