### PR TITLE
remove dependency on Vagrant Triggers

### DIFF
--- a/scaleio/README.md
+++ b/scaleio/README.md
@@ -19,12 +19,9 @@ Other Optional Software Installations for Container Usage (edit the Vagrant file
 
 ## Requirements:
 
-The setup requires the `vagrant-triggers` plugin to be installed, you can do so by running:
-
-`vagrant plugin install vagrant-triggers`
+VirtualBox and Vagrant
 
 For optional proxy setup, make sure you have the `vagrant-proxyconf` plugin installed.
-
 
 ## Usage
 
@@ -49,12 +46,13 @@ If set to `True` (default), a fully functional ScaleIO cluster is installed with
 If set to `False`, three base VMs are installed with IM running on the machine named MDM1. To install your cluster when using `clusterinstall=False` you do `vagrant up` as usual but once complete use your web browser and point it to https://192.168.50.12. Login with `admin` and `Scaleio123`. From here you can deploy a new ScaleIO cluster using IM, great for demo and learning purposes.
 
 ### Example CSV file for deployment of ScaleIO cluster using IM:
-`
+
+```
 IPs,Password,Operating System,Is MDM/TB,Is SDS,SDS Device List,Is SDC
 192.168.50.12,vagrant,linux,Primary,Yes,/home/vagrant/scaleio1,Yes
 192.168.50.13,vagrant,linux,Secondary,Yes,/home/vagrant/scaleio1,Yes
 192.168.50.11,vagrant,linux,TB,Yes,/home/vagrant/scaleio1,Yes
-`
+```
 
 ### Docker, REX-Ray, and Mesos Installation
 

--- a/scaleio/Vagrantfile
+++ b/scaleio/Vagrantfile
@@ -73,15 +73,6 @@ Vagrant.configure("2") do |config|
   end
   #config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 
-  if dockerinstall == "True"
-    config.trigger.after :up, :stdout => true, :vm => ["mdm2"] do
-      info "Restarting Docker on all nodes"
-      run "vagrant ssh tb -c 'sudo service docker restart'"
-      run "vagrant ssh mdm1 -c 'sudo service docker restart'"
-      run "vagrant ssh mdm2 -c 'sudo service docker restart'"
-    end
-  end
-
   scaleio_nodes.each do |node|
     config.vm.define node[:hostname] do |node_config|
       node_config.vm.box = "#{vagrantbox}"

--- a/scaleio/scripts/rexray.sh
+++ b/scaleio/scripts/rexray.sh
@@ -18,4 +18,7 @@ scaleio:
   storagePoolName: pool1
   thinOrThick: ThinProvisioned
 EOF
-service rexray restart
+sed -i '/KillMode/a RestartSec=10' /etc/systemd/system/rexray.service
+sed -i '/KillMode/a Restart=always' /etc/systemd/system/rexray.service
+rexray start
+systemctl enable rexray


### PR DESCRIPTION
updated the rexray systemd service to continually try and restart every 10 seconds if the service isn't starting. This negates the need to use the vagrant triggers plugin any longer

Signed-off-by: kacole2 <kendrickcoleman@gmail.com>