### PR TITLE
Add VERIFYFILES function, reconfigure start order and rearrange Docker Swarm install

### DIFF
--- a/scaleio/.gitignore
+++ b/scaleio/.gitignore
@@ -5,3 +5,4 @@ ScaleIO*
 .DS_Store
 gui/
 swarm_worker_token
+swarm_manager_token

--- a/scaleio/Vagrantfile
+++ b/scaleio/Vagrantfile
@@ -13,7 +13,7 @@ password="Scaleio123"
 domain = 'scaleio.local'
 
 # add your nodes here
-nodes = ['mdm1', 'tb', 'mdm2']
+nodes = ['tb', 'mdm1', 'mdm2']
 
 # add your IPs here
 network = "192.168.50"
@@ -57,6 +57,13 @@ if ENV['SCALEIO_MESOS_INSTALL']
   mesosinstall = ENV['SCALEIO_MESOS_INSTALL'].to_s.downcase
 else
   mesosinstall = "false"
+end
+
+# Verify that the ScaleIO package has the correct size
+if ENV['VERIFYFILES']
+  verifyfiles = ENV['VERIFYFILES'].to_s.downcase
+else
+  verifyfiles = "true"
 end
 
 # version of installation package
@@ -115,7 +122,7 @@ Vagrant.configure("2") do |config|
         # node_config.vm.network "forwarded_port", guest: 6611, host: 6611
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/mdm1.sh"
-          s.args = "-o #{os} -zo #{zip_os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall} -p #{password} -c #{clusterinstall} -dk #{dockerinstall} -r #{rexrayinstall} -ds #{swarminstall} -ms #{mesosinstall}"
+          s.args = "-o #{os} -zo #{zip_os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -tb #{tbip} -i #{siinstall} -p #{password} -c #{clusterinstall} -dk #{dockerinstall} -r #{rexrayinstall} -ds #{swarminstall} -ms #{mesosinstall}"
         end
       end
 
@@ -123,7 +130,7 @@ Vagrant.configure("2") do |config|
         node_config.vm.network "private_network", ip: "#{tbip}"
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/tb.sh"
-          s.args = "-o #{os} -zo #{zip_os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -tb #{tbip} -i #{siinstall} -c #{clusterinstall} -dk #{dockerinstall} -r #{rexrayinstall} -ds #{swarminstall} -ms #{mesosinstall}"
+          s.args = "-o #{os} -zo #{zip_os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -tb #{tbip} -i #{siinstall} -c #{clusterinstall} -dk #{dockerinstall} -r #{rexrayinstall} -ds #{swarminstall} -ms #{mesosinstall} -vf #{verifyfiles}"
         end
       end
 
@@ -131,7 +138,7 @@ Vagrant.configure("2") do |config|
         node_config.vm.network "private_network", ip: "#{secondmdmip}"
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/mdm2.sh"
-          s.args = "-o #{os} -zo #{zip_os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall} -t #{tbip} -p #{password} -c #{clusterinstall} -dk #{dockerinstall} -r #{rexrayinstall} -ds #{swarminstall} -ms #{mesosinstall}"
+          s.args = "-o #{os} -zo #{zip_os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -tb #{tbip} -i #{siinstall} -p #{password} -c #{clusterinstall} -dk #{dockerinstall} -r #{rexrayinstall} -ds #{swarminstall} -ms #{mesosinstall}"
         end
       end
     end

--- a/scaleio/scripts/mdm2.sh
+++ b/scaleio/scripts/mdm2.sh
@@ -36,7 +36,7 @@ do
     SECONDMDMIP="$2"
     shift
     ;;
-    -t|--tbip)
+    -tb|--tbip)
     TBIP="$2"
     shift
     ;;
@@ -155,6 +155,7 @@ if [ "${DOCKERINSTALL}" == "true" ]; then
   usermod -aG docker vagrant
   echo "Setting Docker service to Start on boot"
   chkconfig docker on
+  service docker restart
 fi
 
 if [ "${REXRAYINSTALL}" == "true" ]; then


### PR DESCRIPTION
A few additions and changes to the Vagrant ScaleIO setup:

* Configuring the ScaleIO nodes to start in the right order: TB, MDM1, MDM2
* Adding an option `VERIFYFILES` in the `Vagrantfile` to verify the downloaded ScaleIO file size compared to the one available on downloads.emc.com
* Added the `VERIFYFILES` function in `tb.sh`
* Reconfigured the order the Docker Swarm installation takes place:
    * TB starts as manager
    * MDM1 joins as manager
    * TB is demoted to worker
* Added a Docker Swarm manager token to be used in the new installation order
* Using `rsync` instead of `cp` when adding files to the `gui` directory to remove unnecessary copying
* Adding `service docker restart` to the Docker install function to make sure Docker is always started even without REX-Ray being installed
* Homogenized how the `TBIP` is sent to the scripts

Signed-off-by: <jonas.rosland@gmail.com>