### PR TITLE
fix #48 line endings for windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# force LF line endings on checkout for windows.
+*.sh eol=lf


### PR DESCRIPTION
Force line endings to LF for sh files on windows