### PR TITLE
updated Vagrant Box from CentOS 7.1 to 7.3

### DIFF
--- a/scaleio/Vagrantfile
+++ b/scaleio/Vagrantfile
@@ -2,10 +2,10 @@
 # Many thanks to this post by James Carr: http://blog.james-carr.org/2013/03/17/dynamic-vagrant-nodes/
 
 # vagrant box
-vagrantbox="centos_7.1"
+vagrantbox="centos_7.3"
 
 # vagrant box url
-vagrantboxurl="https://github.com/CommanderK5/packer-centos-template/releases/download/0.7.1/vagrant-centos-7.1.box"
+vagrantboxurl="https://github.com/CommanderK5/packer-centos-template/releases/download/0.7.3/vagrant-centos-7.3.box"
 
 # scaleio admin password
 password="Scaleio123"


### PR DESCRIPTION
The old CentOS box was no longer working correctly with new versions of Vagrant and VirtualBox. This update has been tested and works against Vagrant 1.9.5 and VirtualBox 5.1.22

Signed-off-by: Kenny Coleman <kcoleman@finalcutpro.local>