### PR TITLE
Kubernetes 1.9.1 plus CSI Disable Option

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -23,6 +23,7 @@ Environment Details:
 Set the following environment variables depending on your needs:
 
  - `K8S_VERSION` - Default is `1.9.0`. Set to version tag of Kubernetes release you would like to install.
+ - `K8S_CSI` - Default is `true`. Set to `false` if you want to use Kubernetes with CSI disabled or if you want to use the built-in scaleio driver.
  - `NODE_MEMORY` - Default is `3072`. Recommended memory is at least 1024MB for node01 and node02. Master will always use 2048MB
  - `SCALEIO_INSTALL` - Default is `true`. If `true` will deploy a 3-node ScaleIO cluster.
  - `VERIFY_FILES` - Default is `true`. This will verify the ScaleIO package is available for download.

--- a/kubernetes/Vagrantfile
+++ b/kubernetes/Vagrantfile
@@ -41,7 +41,14 @@ end
 if ENV['K8S_VERSION']
   k8s_version = ENV['K8S_VERSION'].to_s.downcase
 else
-  k8s_version = "1.9.0"
+  k8s_version = "1.9.1"
+end
+
+# Enable Alpha Support for CSI
+if ENV['K8S_CSI']
+  k8s_csi = ENV['K8S_CSI'].to_s.downcase
+else
+  k8s_csi = "true"
 end
 
 # In some cases more memory is needed for applications.
@@ -105,7 +112,7 @@ Vagrant.configure("2") do |config|
 
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/master.sh"
-          s.args = "-k8sv #{k8s_version} -msip #{master_ip} -n1ip #{node01_ip} -n2ip #{node02_ip} -si #{scaleio_install} -vf #{verifyfiles}"
+          s.args = "-k8sv #{k8s_version} -csi #{k8s_csi} -msip #{master_ip} -n1ip #{node01_ip} -n2ip #{node02_ip} -si #{scaleio_install} -vf #{verifyfiles}"
         end
       end
 
@@ -116,7 +123,7 @@ Vagrant.configure("2") do |config|
 
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/node01.sh"
-          s.args = "-k8sv #{k8s_version} -msip #{master_ip} -n1ip #{node01_ip} -n2ip #{node02_ip} -si #{scaleio_install} -vf #{verifyfiles}"
+          s.args = "-k8sv #{k8s_version} -csi #{k8s_csi} -msip #{master_ip} -n1ip #{node01_ip} -n2ip #{node02_ip} -si #{scaleio_install} -vf #{verifyfiles}"
         end
       end
 
@@ -127,7 +134,7 @@ Vagrant.configure("2") do |config|
 
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/node02.sh"
-          s.args = "-k8sv #{k8s_version} -msip #{master_ip} -n1ip #{node01_ip} -n2ip #{node02_ip} -si #{scaleio_install} -sp #{scaleio_password} -vf #{verifyfiles}"
+          s.args = "-k8sv #{k8s_version} -csi #{k8s_csi} -msip #{master_ip} -n1ip #{node01_ip} -n2ip #{node02_ip} -si #{scaleio_install} -sp #{scaleio_password} -vf #{verifyfiles}"
         end
       end
 

--- a/kubernetes/scripts/examples/scaleio/secret.yaml
+++ b/kubernetes/scripts/examples/scaleio/secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scaleio
+  labels:
+    name: scaleio
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scaleio-secret
+  namespace: scaleio
+type: kubernetes.io/scaleio
+data:
+  username: YWRtaW4=
+  password: U2NhbGVpbzEyMw==

--- a/kubernetes/scripts/examples/scaleio/storageclass.yaml
+++ b/kubernetes/scripts/examples/scaleio/storageclass.yaml
@@ -1,0 +1,15 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  name: scaleio
+provisioner: kubernetes.io/scaleio
+parameters:
+  gateway: https://192.168.50.11:8443/api 
+  protectionDomain: pd1
+  storagePool: pd1pool1
+  system: cluster1
+  secretRef: scaleio-secret
+  secretNamespace: scaleio
+  fsType: xfs

--- a/kubernetes/scripts/k8s-node.sh
+++ b/kubernetes/scripts/k8s-node.sh
@@ -8,6 +8,10 @@ do
     K8S_VERSION="$2"
     shift
     ;;
+    -csi|--K8S_CSI)
+    K8S_CSI="$2"
+    shift
+    ;;
     -msip|--master_ip)
     MASTER_IP="$2"
     shift
@@ -119,6 +123,11 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 EOF
+
+if [ "$K8S_CSI" == "false" ]; then
+  sed -i '/feature-gates/d' kubelet.service
+  sed -i '/enable-controller/d' kubelet.service
+fi
 
 echo "Starting kubelet service"
 mv kubelet.service /etc/systemd/system/

--- a/kubernetes/scripts/master.sh
+++ b/kubernetes/scripts/master.sh
@@ -8,6 +8,10 @@ do
     K8S_VERSION="$2"
     shift
     ;;
+    -csi|--K8S_CSI)
+    K8S_CSI="$2"
+    shift
+    ;;
     -msip|--master_ip)
     MASTER_IP="$2"
     shift
@@ -40,6 +44,7 @@ do
 done
 
 echo K8S_VERSION = "${K8S_VERSION}"
+echo K8S_CSI = "${K8S_CSI}"
 echo MASTER_IP = "${MASTER_IP}"
 echo NODE01_IP = "${NODE01_IP}"
 echo NODE02_IP = "${NODE02_IP}"
@@ -206,7 +211,7 @@ done
 cd /vagrant
 
 #Install Kubernetes Components
-/vagrant/scripts/k8s-controller.sh -k8sv ${K8S_VERSION} -msip ${MASTER_IP} -n1ip ${NODE01_IP} -n2ip ${NODE02_IP} -si ${SCALEIO_INSTALL}
+/vagrant/scripts/k8s-controller.sh -k8sv ${K8S_VERSION} -csi ${K8S_CSI} -msip ${MASTER_IP} -n1ip ${NODE01_IP} -n2ip ${NODE02_IP} -si ${SCALEIO_INSTALL}
 
 if [[ -n $1 ]]; then
   echo "Last line of file specified as non-opt/last argument:"

--- a/kubernetes/scripts/node01.sh
+++ b/kubernetes/scripts/node01.sh
@@ -8,6 +8,10 @@ do
     K8S_VERSION="$2"
     shift
     ;;
+    -csi|--K8S_CSI)
+    K8S_CSI="$2"
+    shift
+    ;;
     -msip|--master_ip)
     MASTER_IP="$2"
     shift
@@ -39,6 +43,7 @@ do
   shift
 done
 echo K8S_VERSION = "${K8S_VERSION}"
+echo K8S_CSI = "${K8S_CSI}"
 echo MASTER_IP = "${MASTER_IP}"
 echo NODE01_IP = "${NODE01_IP}"
 echo NODE02_IP = "${NODE02_IP}"
@@ -94,8 +99,7 @@ if [ "${SCALEIO_INSTALL}" == "true" ]; then
 fi
 
 #Install Kubernetes Components
-/vagrant/scripts/k8s-node.sh -k8sv ${K8S_VERSION} -msip ${MASTER_IP} -n1ip ${NODE01_IP} -n2ip ${NODE02_IP}
-
+/vagrant/scripts/k8s-node.sh -k8sv ${K8S_VERSION} -csi ${K8S_CSI} -msip ${MASTER_IP} -n1ip ${NODE01_IP} -n2ip ${NODE02_IP}
 
 if [[ -n $1 ]]; then
   echo "Last line of file specified as non-opt/last argument:"

--- a/kubernetes/scripts/node02.sh
+++ b/kubernetes/scripts/node02.sh
@@ -8,6 +8,10 @@ do
     K8S_VERSION="$2"
     shift
     ;;
+    -csi|--K8S_CSI)
+    K8S_CSI="$2"
+    shift
+    ;;
     -msip|--master_ip)
     MASTER_IP="$2"
     shift
@@ -39,6 +43,7 @@ do
   shift
 done
 echo K8S_VERSION = "${K8S_VERSION}"
+echo K8S_CSI = "${K8S_CSI}"
 echo MASTER_IP = "${MASTER_IP}"
 echo NODE01_IP = "${NODE01_IP}"
 echo NODE02_IP = "${NODE02_IP}"
@@ -110,8 +115,7 @@ systemctl status docker
 sleep 5
 
 #Install Kubernetes Components
-/vagrant/scripts/k8s-node.sh -k8sv ${K8S_VERSION} -msip ${MASTER_IP} -n1ip ${NODE01_IP} -n2ip ${NODE02_IP}
-
+/vagrant/scripts/k8s-node.sh -k8sv ${K8S_VERSION} -csi ${K8S_CSI} -msip ${MASTER_IP} -n1ip ${NODE01_IP} -n2ip ${NODE02_IP}
 
 if [[ -n $1 ]]; then
   echo "Last line of file specified as non-opt/last argument:"


### PR DESCRIPTION
This updates Kubernetes to 1.9.1 and also provides an option to disable CSI support. Using K8S_CSI=false will disable all CSI-related components and allow use of the built-in ScaleIO driver.